### PR TITLE
Connection manager button text fixed

### DIFF
--- a/application/sources/main_window.cpp
+++ b/application/sources/main_window.cpp
@@ -206,13 +206,13 @@ void MainWindow::ProcessNetworkOperationResult(const std::string& port_name, con
             if(!network_connection_is_open)
             {
                 pWidgetConnectionManager->line_edit_port_name->setReadOnly(true);
-                pWidgetConnectionManager->line_edit_port_name->setText(ConnectionManagerWidget::button_close_connection_text);
+                pWidgetConnectionManager->button_open_close_connection->setText(ConnectionManagerWidget::button_close_connection_text);
                 network_connection_is_open = true;
             }
             else
             {
                 pWidgetConnectionManager->line_edit_port_name->setReadOnly(false);
-                pWidgetConnectionManager->line_edit_port_name->setText(ConnectionManagerWidget::button_open_connection_text);
+                pWidgetConnectionManager->button_open_close_connection->setText(ConnectionManagerWidget::button_open_connection_text);
                 network_connection_is_open = false;
             }
         }


### PR DESCRIPTION
Details:
    - button text changes to "Close Serial Port" after successful connection
    - button text changes back to "Open Serial Port" after closing connection